### PR TITLE
Scan type auth header

### DIFF
--- a/V1/VAddy-WebApi-Crawl-ja.md
+++ b/V1/VAddy-WebApi-Crawl-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Crawl Document
 ============================
 
-Document Version 1.0.2  
+Document Version 1.0.4  
 
 VAddy WebAPI Crawl仕様書です。
 本仕様では、VAddyのクロール情報の取得を定義します。
@@ -29,9 +29,10 @@ page, sort, search_labelはオプション項目です。検索結果は1回で�
 - sortはasc(昇順)もしくはdesc(降順)を指定します。指定しない場合はデフォルトはdescです。
 - search_labelを付けない場合は全てのクロール情報を対象に一覧を取得します。search_labelを付けると、指定のキーワードで部分一致した検索結果を返します。
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
 
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
 
 #### リクエスト例 (最新の30件を取得)：
 

--- a/V1/VAddy-WebApi-Crawl.md
+++ b/V1/VAddy-WebApi-Crawl.md
@@ -1,7 +1,7 @@
 VAddy Web API Crawl Document
 ======================
 
-Document Version 1.0.2
+Document Version 1.0.4
 
 This specification defines to operate crawling information.
 
@@ -30,8 +30,11 @@ Parameters of page, sort, search_label are optional. Each request can fetch at m
 - sort parameter: asc or desc. Default is desc.
 - search_label parameter: Partial-word search. Default is null(search all records).   
 
-The auth_key is WebAPI authentication key. You can get/create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
-Set Your UserID(LoginID) of VAddy management page on the user parameter.
+The `auth_key` is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
+The `auth_key` can also be specified by `X-API-KEY` in http header.
+
+Set Your UserID(LoginID) of VAddy management page on `user` parameter.  
+
 
 
 

--- a/V1/VAddy-WebApi-ja.md
+++ b/V1/VAddy-WebApi-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Scan Document
 ======================
 
-Document Version 1.0.3  
+Document Version 1.0.4  
 
 VAddy WebAPI仕様書です。
 本仕様では、VAddyのスキャン開始、スキャンキャンセル、スキャン結果の取得の3つを定義します。
@@ -22,9 +22,10 @@ Method : POST
 
 crawl_idはオプション項目です。指定がない場合は最新のクロールデータを利用して検査します。クロールIDの値は、管理画面にログインし、Proxy Crawling画面からご確認ください。
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
 
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
 
 ### Scan開始レスポンス
 #### 成功

--- a/V1/VAddy-WebApi.md
+++ b/V1/VAddy-WebApi.md
@@ -1,7 +1,7 @@
 VAddy Web API Scan Document
 ======================
 
-Document Version 1.0.3
+Document Version 1.0.4
 
 This specification defines "start scan", "cancel scan" and "get scan results".
 
@@ -23,8 +23,11 @@ Method : POST
 
 "crawl_id" is optional. If you don't specify it, VAddy uses the latest crawl data for scan. You can see the crawl ID number in the Proxy Crawling page of console page.
 
-The auth_key is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
-Set Your UserID(LoginID) of VAddy management page on user parameter.
+The `auth_key` is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
+The `auth_key` can also be specified by `X-API-KEY` in http header.
+
+Set Your UserID(LoginID) of VAddy management page on `user` parameter.  
+
 
 
 

--- a/VAddy-WebApi-Crawl-ja.md
+++ b/VAddy-WebApi-Crawl-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Crawl Document
 ============================
 
-Document Version 2.0.0  
+Document Version 2.0.1  
 
 VAddy WebAPI Crawl仕様書です。
 本仕様では、VAddyのクロール情報の取得を定義します。
@@ -28,10 +28,11 @@ page, sort, search_labelはオプション項目です。検索結果は1回で�
 - sortはasc(昇順)もしくはdesc(降順)を指定します。指定しない場合はデフォルトはdescです。
 - search_labelを付けない場合は全てのクロール情報を対象に一覧を取得します。search_labelを付けると、指定のキーワードで部分一致した検索結果を返します。
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
 
-project_idは、検査対象サーバを管理するID。 Server画面にProjectIDとして表示されます。
+`project_id`は、検査対象サーバを管理するID。 Server画面にProjectIDとして表示されます。
 
 #### リクエスト例 (最新の30件を取得)：
 

--- a/VAddy-WebApi-Crawl.md
+++ b/VAddy-WebApi-Crawl.md
@@ -1,7 +1,7 @@
 VAddy Web API Crawl Document
 ======================
 
-Document Version 2.0.0
+Document Version 2.0.1
 
 This specification defines to operate crawling information.
 
@@ -29,10 +29,11 @@ Parameters of page, sort, search_label are optional. Each request can fetch at m
 - sort parameter: asc or desc. Default is desc.
 - search_label parameter: Partial-word search. Default is null(search all records).   
 
-The auth_key is WebAPI authentication key. You can get/create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
-Set Your UserID(LoginID) of VAddy management page on the user parameter.
 
+The `auth_key` is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
+The `auth_key` can also be specified by `X-API-KEY` in http header.
 
+Set Your UserID(LoginID) of VAddy management page on `user` parameter.  
 
 #### Request example
 

--- a/VAddy-WebApi-CrawlDelete-ja.md
+++ b/VAddy-WebApi-CrawlDelete-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Crawl Delete Document
 ============================
 
-Document Version 2.0.0  
+Document Version 2.0.1  
 
 VAddy WebAPI クロールデータ削除の仕様書です。
 
@@ -22,10 +22,11 @@ Method : POST
     crawl_id=2
 
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
 
-project_numberは、プロジェクト単位で自動付与される数字の番号です。  
+`project_number`は、プロジェクト単位で自動付与される数字の番号です。  
 https://console.vaddy.net/project/123  
 のように各プロジェクト画面のURLの末尾にある数字がproject_numberです。  
 project_idとは異なりますのでご注意ください。  

--- a/VAddy-WebApi-ScanResultList-ja.md
+++ b/VAddy-WebApi-ScanResultList-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Scan Result List Document
 ============================
 
-Document Version 2.0.0  
+Document Version 2.0.1  
 
 VAddy WebAPI 検査結果一覧取得の仕様書です。
 
@@ -20,10 +20,12 @@ Method : GET
 
 検索結果は1回で最大20件取得できます。結果は最新順（降順）になります。  
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
 
-project_numberは、プロジェクト単位で自動付与される数字の番号です。  
+
+`project_number`は、プロジェクト単位で自動付与される数字の番号です。  
 https://console.vaddy.net/project/123  
 のように各プロジェクト画面のURLの末尾にある数字がproject_numberです。  
 project_idとは異なりますのでご注意ください。  

--- a/VAddy-WebApi-ja.md
+++ b/VAddy-WebApi-ja.md
@@ -20,11 +20,15 @@ Method : POST
     crawl_id=30
     scan_type="SQLI,XSS,RFI,..."
 
-crawl_idはオプション項目です。指定がない場合は最新のクロールデータを利用して検査します。クロールIDの値は、管理画面にログインし、Proxy Crawling画面からご確認ください。
+`crawl_id`はオプション項目です。指定がない場合は最新のクロールデータを利用して検査します。クロールIDの値は、管理画面にログインし、Proxy Crawling画面からご確認ください。
 
 `scan_type` はオプション項目です。指定が無い場合は全ての検査が実行されます。カンマ区切りで指定します。設定できる検査項目の一覧はこちらをご覧ください。 [検査項目指定オプションの一覧](https://github.com/vaddy/WebAPI-document/blob/master/VAddy-WebApi-ScanType.md)
 
-project_idは、検査対象サーバを管理するID。 Server画面にProjectIDとして表示されます。
+`auth_key`は、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
+管理画面のログインIDを`user`パラメータに、API Auth Keyを`auth_key`パラメータにセットしてください。  
+`auth_key` はHTTPヘッダーの `X-API-KEY` に指定することもできます。
+
+`project_id`は、検査対象サーバを管理するID。 Server画面にProjectIDとして表示されます。
 
 ### Scan開始レスポンス
 #### 成功

--- a/VAddy-WebApi-ja.md
+++ b/VAddy-WebApi-ja.md
@@ -1,7 +1,7 @@
 VAddy Web API Scan Document
 ======================
 
-Document Version 2.0.1
+Document Version 2.0.2
 
 VAddy WebAPI仕様書です。
 本仕様では、VAddyのスキャン開始、スキャンキャンセル、スキャン結果の取得の3つを定義します。
@@ -18,11 +18,11 @@ Method : POST
     auth_key=123456
     project_id=6eb1f9fcbdb6a5a
     crawl_id=30
+    scan_type="SQLI,XSS,RFI,..."
 
 crawl_idはオプション項目です。指定がない場合は最新のクロールデータを利用して検査します。クロールIDの値は、管理画面にログインし、Proxy Crawling画面からご確認ください。
 
-auth_keyは、ユーザ毎に発行する認証キーです。VAddyログイン後のWebAPI管理画面にて取得してください。  
-管理画面のUser Idをuserパラメータに、API Auth Keyをauth_keyパラメータにセットしてください。  
+`scan_type` はオプション項目です。指定が無い場合は全ての検査が実行されます。カンマ区切りで指定します。設定できる検査項目の一覧はこちらをご覧ください。 [検査項目指定オプションの一覧](https://github.com/vaddy/WebAPI-document/blob/master/VAddy-WebApi-ScanType.md)
 
 project_idは、検査対象サーバを管理するID。 Server画面にProjectIDとして表示されます。
 

--- a/VAddy-WebApi.md
+++ b/VAddy-WebApi.md
@@ -1,7 +1,7 @@
 VAddy Web API Scan Document
 ======================
 
-Document Version 2.0.1
+Document Version 2.0.2
 
 This specification defines "start scan", "cancel scan" and "get scan results".
 
@@ -19,11 +19,11 @@ Method : POST
     auth_key=123456
     project_id=6eb1f9fcbdb6a5a
     crawl_id=30
+    scan_type="SQLI,XSS,RFI,..."
 
 "crawl_id" is optional. If you don't specify it, VAddy uses the latest crawl data for scan. You can see the crawl ID number in the Proxy Crawling page of console page.
 
-The auth_key is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
-Set Your UserID(LoginID) of VAddy management page on user parameter.  
+`scan_type` is optional. [Scan type list document](https://github.com/vaddy/WebAPI-document/blob/master/VAddy-WebApi-ScanType.md)
 
 The project_id is grouping ID for scan target servers.  It shows on the server menu of VAddy console screen.  
 

--- a/VAddy-WebApi.md
+++ b/VAddy-WebApi.md
@@ -21,11 +21,16 @@ Method : POST
     crawl_id=30
     scan_type="SQLI,XSS,RFI,..."
 
-"crawl_id" is optional. If you don't specify it, VAddy uses the latest crawl data for scan. You can see the crawl ID number in the Proxy Crawling page of console page.
+`crawl_id` is optional. If you don't specify it, VAddy uses the latest crawl data for scan. You can see the crawl ID number in the Proxy Crawling page of console page.
 
 `scan_type` is optional. [Scan type list document](https://github.com/vaddy/WebAPI-document/blob/master/VAddy-WebApi-ScanType.md)
 
-The project_id is grouping ID for scan target servers.  It shows on the server menu of VAddy console screen.  
+The `auth_key` is WebAPI authentication key. You can create this key on VAddy management page(https://console.vaddy.net/user/webapi).  
+The `auth_key` can also be specified by `X-API-KEY` in http header.
+
+Set Your UserID(LoginID) of VAddy management page on `user` parameter.  
+
+The `project_id` is grouping ID for scan target servers.  It shows on the server menu of VAddy console screen.  
 
 
 ### Scan Start Response


### PR DESCRIPTION
- 検査項目指定オプションを追加
- APIキーの指定方法にHTTPヘッダーを使うパターンを追加
